### PR TITLE
Reset 'this.currentGeohashList' to [] when external collaborations are applied

### DIFF
--- a/src/contributors/MapContributor.ts
+++ b/src/contributors/MapContributor.ts
@@ -134,6 +134,7 @@ export class MapContributor extends Contributor {
     }
     public fetchData(collaborationEvent: CollaborationEvent): Observable<FeatureCollection> {
         this.currentStringedTilesList = [];
+        this.currentGeohashList = [];
         if (collaborationEvent.operation.toString() === OperationEnum.remove.toString()) {
             if (collaborationEvent.all || collaborationEvent.id === this.identifier) {
                 this.onRemoveBboxBus.next(true);
@@ -143,7 +144,6 @@ export class MapContributor extends Contributor {
         if (this.zoom < this.zoomLevelForTestCount) {
             this.fetchType = fetchType.geohash;
             this.geojsondata.features = [];
-            this.currentGeohashList = [];
             return this.fetchDataGeohashGeoaggregate(this.geohashList);
         } else if (this.zoom >= this.zoomLevelForTestCount) {
             const pwithin = this.mapExtend[1] + ',' + this.mapExtend[2] + ',' + this.mapExtend[3] + ',' + this.mapExtend[0];

--- a/src/contributors/MapContributor.ts
+++ b/src/contributors/MapContributor.ts
@@ -143,6 +143,7 @@ export class MapContributor extends Contributor {
         if (this.zoom < this.zoomLevelForTestCount) {
             this.fetchType = fetchType.geohash;
             this.geojsondata.features = [];
+            this.currentGeohashList = [];
             return this.fetchDataGeohashGeoaggregate(this.geohashList);
         } else if (this.zoom >= this.zoomLevelForTestCount) {
             const pwithin = this.mapExtend[1] + ',' + this.mapExtend[2] + ',' + this.mapExtend[3] + ',' + this.mapExtend[0];

--- a/src/contributors/TopoMapContributor.ts
+++ b/src/contributors/TopoMapContributor.ts
@@ -88,6 +88,7 @@ export class TopoMapContributor extends MapContributor {
         this.maxValueGeoHash = 0;
         if (this.zoom < this.zoomLevelForTestCount) {
             this.geojsondata.features = [];
+            this.currentGeohashList = [];
             return this.fetchDataGeohashGeoaggregate(this.geohashList);
         } else if (this.zoom >= this.zoomLevelForTestCount) {
             const pwithin = this.mapExtend[1] + ',' + this.mapExtend[2] + ',' + this.mapExtend[3] + ',' + this.mapExtend[0];

--- a/src/contributors/TopoMapContributor.ts
+++ b/src/contributors/TopoMapContributor.ts
@@ -80,6 +80,7 @@ export class TopoMapContributor extends MapContributor {
     }
 
     public fetchData(collaborationEvent: CollaborationEvent): Observable<any> {
+        this.currentGeohashList = [];
         if (collaborationEvent.operation.toString() === OperationEnum.remove.toString()) {
             if (collaborationEvent.all || collaborationEvent.id === this.identifier) {
                 this.onRemoveBboxBus.next(true);
@@ -88,7 +89,6 @@ export class TopoMapContributor extends MapContributor {
         this.maxValueGeoHash = 0;
         if (this.zoom < this.zoomLevelForTestCount) {
             this.geojsondata.features = [];
-            this.currentGeohashList = [];
             return this.fetchDataGeohashGeoaggregate(this.geohashList);
         } else if (this.zoom >= this.zoomLevelForTestCount) {
             const pwithin = this.mapExtend[1] + ',' + this.mapExtend[2] + ',' + this.mapExtend[3] + ',' + this.mapExtend[0];


### PR DESCRIPTION
Fix #169 