### PR TITLE
fix: features crossing the 180th meridian don't take the shortest path

### DIFF
--- a/src/contributors/MapContributor.ts
+++ b/src/contributors/MapContributor.ts
@@ -982,6 +982,17 @@ export class MapContributor extends Contributor {
                             delete feature.properties[k];
                         }
                     });
+
+                    const coordinates: Array<Array<number>> = (feature.geometry as any).coordinates;
+                    coordinates.forEach((point, idx) => {
+                        if (idx <= coordinates.length - 2) {
+                            if (point[0] - coordinates[idx + 1][0] > 180) {
+                                coordinates[idx + 1][0] += 360;
+                            } else if (coordinates[idx + 1][0] - point[0] > 180) {
+                                coordinates[idx + 1][0] += -360;
+                            }
+                        }
+                    });
                     sourceData.push(feature);
                 });
             }


### PR DESCRIPTION
After a few tests with around 9000 trails adding this loop only increases the display time by about 50ms.
Fix gisaia/ARLAS-wui#531