### PR TITLE
fix: when leaving an item, properly capture its id

### DIFF
--- a/src/contributors/MapContributor.ts
+++ b/src/contributors/MapContributor.ts
@@ -766,7 +766,7 @@ export class MapContributor extends Contributor {
         let isleaving = false;
         let id = elementidentifier.idValue;
         if (id.split('-')[0] === 'leave') {
-            id = id.split('-')[1];
+            id = id.split('leave-', 2)[1];
             isleaving = true;
         }
         return {


### PR DESCRIPTION
When the id is an uuid, there are multiple groups that can be created by splitting on a -